### PR TITLE
bug fix : predict raises ValueError when doing multiple text and diff…

### DIFF
--- a/python/fasttext_module/fasttext/FastText.py
+++ b/python/fasttext_module/fasttext/FastText.py
@@ -152,12 +152,10 @@ class _FastText(object):
 
         if type(text) == list:
             text = [check(entry) for entry in text]
-            predictions = self.f.multilinePredict(
+            all_labels, all_probs = self.f.multilinePredict(
                 text, k, threshold, on_unicode_error)
-            dt = np.dtype([('probability', 'float64'), ('label', 'object')])
-            result_as_pair = np.array(predictions, dtype=dt)
 
-            return result_as_pair['label'].tolist(), result_as_pair['probability']
+            return all_labels, all_probs
         else:
             text = check(text)
             predictions = self.f.predict(text, k, threshold, on_unicode_error)


### PR DESCRIPTION
…erent number of values are above threshold

Summary: This commit fixes the issue #846 : https://github.com/facebookresearch/fastText/issues/846

Reviewed By: EdouardGrave

Differential Revision: D16966157

fbshipit-source-id: 030c98b571a749d94f776f3e618ead4f469d16ab